### PR TITLE
Bug fix for the ControlModel class 

### DIFF
--- a/soupy/modeling/controlModel.py
+++ b/soupy/modeling/controlModel.py
@@ -168,7 +168,7 @@ class ControlModel:
         self.problem.evalGradientParameter(x, mg)
         self.qoi.grad(PARAMETER,x,tmp)
         mg.axpy(1., tmp)
-        return math.sqrt(mg.inner(tmp))
+        return math.sqrt(mg.inner(mg))
 
     
     def evalGradientControl(self,x, mg):
@@ -192,7 +192,7 @@ class ControlModel:
         # print("MIDFIT GRAD: ", tmp.get_local())
         mg.axpy(1., tmp)
         # print("OVERALL GRAD: ", mg.get_local())
-        return math.sqrt(mg.inner(tmp))
+        return math.sqrt(mg.inner(mg))
 
     
     def setLinearizationPoint(self, x, gauss_newton_approx=False):

--- a/soupy/test/ptest_meanVarRiskMeasureSAA.py
+++ b/soupy/test/ptest_meanVarRiskMeasureSAA.py
@@ -40,14 +40,14 @@ def l2_norm(u,m,z):
     return u**2*dl.dx 
 
 def qoi_for_testing(u,m,z):
-    return u**2*dl.dx + dl.exp(m) * dl.inner(dl.grad(u), dl.grad(u))*dl.ds
+    return u**2*dl.dx + dl.exp(m) * dl.inner(dl.grad(u), dl.grad(u))*dl.ds - dl.inner(z, z)*dl.dx
 
 
 class TestMeanVarRiskMeasureSAA(unittest.TestCase):
     def setUp(self):
         self.reltol = 1e-3
         self.fdtol = 1e-2
-        self.delta = 1e-3
+        self.delta = 1e-4
         self.n_wells_per_side = 3
         self.nx = 20
         self.ny = 20

--- a/soupy/test/ptest_scipyCostWrapper.py
+++ b/soupy/test/ptest_scipyCostWrapper.py
@@ -38,8 +38,7 @@ from soupy import ControlCostFunctional, PDEVariationalControlProblem, \
 from setupPoissonControlProblem import poisson_control_settings, setupPoissonPDEProblem
 
 def qoi_for_testing(u,m,z):
-    return u**2*dl.dx + dl.exp(m) * dl.inner(dl.grad(u), dl.grad(u))*dl.ds
-
+    return u**2*dl.dx + dl.exp(m) * dl.inner(dl.grad(u), dl.grad(u))*dl.ds - dl.inner(z, z)*dl.dx
 
 def u_boundary(x, on_boundary):
     return on_boundary and (x[1] < dl.DOLFIN_EPS or x[1] > 1.0 - dl.DOLFIN_EPS)

--- a/soupy/test/ptest_superquantileSAA.py
+++ b/soupy/test/ptest_superquantileSAA.py
@@ -62,7 +62,7 @@ def l2_norm(u,m,z):
     return u**2*dl.dx 
 
 def qoi_for_testing(u,m,z):
-    return u**2*dl.dx + dl.exp(m) * dl.inner(dl.grad(u), dl.grad(u))*dl.ds
+    return u**2*dl.dx + dl.exp(m) * dl.inner(dl.grad(u), dl.grad(u))*dl.ds - dl.inner(z, z)*dl.dx
 
 
 class TestSuperquantileSAA(unittest.TestCase):
@@ -73,7 +73,7 @@ class TestSuperquantileSAA(unittest.TestCase):
     def setUp(self):
         self.reltol = 1e-3
         self.fdtol = 1e-2
-        self.delta = 1e-3
+        self.delta = 1e-4
         self.n_wells_per_side = 3
         self.nx = 20
         self.ny = 20


### PR DESCRIPTION
Fixed a bug in the computation of the gradient norm in `evalGradientParameter` and `evalGradientControl` within `ControlModel`. 

The output gradient norm is not typically used downstream, but can cause an error where the inner product is negative and its square root is invalid. 

Also updated the QoI in risk measure unit tests to depend on all three variables (state, parameter, control). 