### PR TITLE
MPI-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
    style:
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-24.04
      container:
        image: dcluo28/dibasis:latest
      name: Repo Test

--- a/soupy/collectives/__init__.py
+++ b/soupy/collectives/__init__.py
@@ -13,5 +13,5 @@
 
 from .collective import NullCollective, MultipleSerialPDEsCollective, MultipleSamePartitioningPDEsCollective
 
-from .mpiUtils import allocate_process_sample_sizes
+from .mpiUtils import allocate_process_sample_sizes, allgather_vector_as_numpy, set_local_from_global, get_global
 

--- a/soupy/collectives/mpiUtils.py
+++ b/soupy/collectives/mpiUtils.py
@@ -61,7 +61,7 @@ def set_local_from_global(v, v_np):
     :param v: Vector to set
     :type v: dl.Vector 
     :param v_np: numpy array for global entries
-    :type v: np.ndarray
+    :type v_np: np.ndarray
     """
     
     local_range = v.local_range()

--- a/soupy/optimization/bfgs.py
+++ b/soupy/optimization/bfgs.py
@@ -332,7 +332,9 @@ class BFGS:
                 z_star.axpy(alpha, zhat)
                 if box_bounds is not None:
                     z_star.set_local(np.maximum(z_star.get_local(), param_min))
+                    z_star.apply("")
                     z_star.set_local(np.minimum(z_star.get_local(), param_max))
+                    z_star.apply("")
                 if constraint_projection is not None:
                     constraint_projection.project(z_star)
 

--- a/soupy/optimization/steepestDescent.py
+++ b/soupy/optimization/steepestDescent.py
@@ -179,7 +179,9 @@ class SteepestDescent:
                 z_star.axpy(scale_alpha * alpha, zhat)
                 if box_bounds is not None:
                     z_star.set_local(np.maximum(z_star.get_local(), param_min))
+                    z_star.apply("")
                     z_star.set_local(np.minimum(z_star.get_local(), param_max))
+                    z_star.apply("")
                 if constraint_projection is not None:
                     constraint_projection.project(z_star)
 


### PR DESCRIPTION
Updates for compatibility with fenics' mesh partitioning when using MPI
- Fixed missing calls of `dl.Vector.apply` after `dl.Vector.set_local` when projecting bound constraints in`BFGS` and `SteepestDescent`, ensuring each MPI process has the same optimization variable array.
- `ScipyCostWrapper`: the numpy array for the optimization variable now uses the full, global representation of the optimization variable, as opposed to the partitioned, local representation. 